### PR TITLE
Fixes handle_string bug

### DIFF
--- a/gthack/gtcFuncs.py
+++ b/gthack/gtcFuncs.py
@@ -215,7 +215,7 @@ def main():
         logger.info('method sampleInformation selected \n creating new object of class GtcFunctions')
         if args.fileOutName == None:
             args.fileOutName = 'allSampleInfo.txt'
-        analysisObj = GtcFunctions(args.bpm, args.gtcDir, args.outDir)
+        analysisObj = GtcFunctions(args.bpm, args.bpm_csv, args.gtcDir, args.outDir)
         analysisObj.extractSampleInfo(args.fileOutName, args.prefix, args.recursive)
     
     else:

--- a/gthack/modules/write_gtc.py
+++ b/gthack/modules/write_gtc.py
@@ -32,7 +32,7 @@ def handle_string(value):
     assert len(value) <= 127
     return (
         struct.pack("B", len(value)) + 
-        value.encode() if isinstance(value, str) else value
+        (value.encode() if isinstance(value, str) else value)
     )
 
 def handle_basecalls(value):


### PR DESCRIPTION
Bug: 

https://github.com/CCPM-IO/GThaCk/blob/02330625b8ddf0420d8be5dd04f7dbfeadc651a1/gthack/modules/write_gtc.py#L31-L36

else condition value here doesn't have the `struct.pack(value)` prepended to the value


Other fix: 

- GtcFunctions objects created with the right parameters